### PR TITLE
feat: highlight next early morning high tide

### DIFF
--- a/conditions/templates/conditions/location_forecast.html
+++ b/conditions/templates/conditions/location_forecast.html
@@ -71,6 +71,11 @@
     {% if tide_times %}
       <div class="card-enhanced p-4 sm:p-5 mb-6 w-full max-w-2xl">
         <h2 class="text-base sm:text-lg font-semibold mb-2">Upcoming High Tides</h2>
+        {% if next_early_high_tide %}
+          <p class="text-sm sm:text-base mb-2">
+            Next early morning high tide: {{ next_early_high_tide|date:"D H:i" }}
+          </p>
+        {% endif %}
         <p class="text-sm sm:text-base">
           {% for t in tide_times %}
             {{ t|date:"D H:i" }}{% if not forloop.last %}, {% endif %}

--- a/conditions/views.py
+++ b/conditions/views.py
@@ -167,6 +167,7 @@ def location_forecast(request: HttpRequest, country: str, city: str) -> HttpResp
             next_window = {"start": start, "end": end}
             break
     tide_times = [h["time"] for h in hours if h.get("is_high_tide")]
+    next_early_high_tide = next((t for t in tide_times if t.hour < 9), None)
 
     context = {
         "location": location_data,
@@ -183,6 +184,7 @@ def location_forecast(request: HttpRequest, country: str, city: str) -> HttpResp
         "day_summaries": day_summaries,
         "next_window": next_window,
         "tide_times": tide_times,
+        "next_early_high_tide": next_early_high_tide,
     }
     return render(request, "conditions/location_forecast.html", context)
 


### PR DESCRIPTION
## Summary
- compute next early morning high tide from forecast data
- show next early morning high tide time above the tide list

## Testing
- `uv run ruff check .`
- `uv run python snorkelforecast/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689459419e10833088f7de61bebc3248