### PR TITLE
feat: show tide chart previews on homepage

### DIFF
--- a/conditions/templates/conditions/homepage.html
+++ b/conditions/templates/conditions/homepage.html
@@ -43,7 +43,9 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
           {% for location in popular_locations %}
           <div class="card-enhanced">
-            <div class="h-24 sm:h-32 bg-gradient-to-br from-blue-400 to-blue-600"></div>
+            <img src="{% url 'location_tide_chart' country=location.country_slug city=location.city_slug %}"
+                 alt="24-hour tide chart for {{ location.city }}"
+                 class="w-full h-24 sm:h-32 object-cover" />
             <div class="p-4 sm:p-5">
               <h4 class="text-lg font-semibold text-gray-900">{{ location.city }}</h4>
               <p class="text-sm text-gray-600 mb-2">{{ location.country }}</p>

--- a/conditions/urls.py
+++ b/conditions/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.homepage, name='homepage'),
+    path('<str:country>/<str:city>/tide.png', views.location_tide_chart, name='location_tide_chart'),
     path('<str:country>/<str:city>/image.png', views.location_og_image, name='location_og_image'),
     path('<str:country>/<str:city>/', views.location_forecast, name='location_forecast'),
     path('carboneras/', views.home, name='legacy_home'),  # Legacy redirect


### PR DESCRIPTION
## Summary
- generate 24‑hour tide chart images for each location
- display tide chart previews on homepage cards

## Testing
- `ruff check .`
- `python snorkelforecast/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68949102116883308046ae44f3d26c30