### PR TITLE
feat: improve night mode readability

### DIFF
--- a/conditions/templates/conditions/index.html
+++ b/conditions/templates/conditions/index.html
@@ -69,7 +69,7 @@
     <div class="mt-8 w-full max-w-4xl mx-auto">
       <h2 class="text-lg font-semibold mb-2">Detailed Conditions</h2>
       <table class="w-full text-sm text-left text-gray-700 bg-white shadow rounded text-night-muted bg-night-surface">
-        <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+        <thead class="text-xs text-gray-700 uppercase bg-gray-50 ui-night:text-gray-200 ui-night:bg-gray-800">
           <tr>
             <th scope="col" class="px-6 py-3">Time</th>
             <th scope="col" class="px-6 py-3">Sunrise</th>
@@ -82,8 +82,8 @@
         </thead>
         <tbody>
           {% for h in hours %}
-            <tr class="border-b">
-              <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+            <tr class="border-b ui-night:border-gray-700">
+              <th scope="row" class="px-6 py-4 font-medium text-gray-900 ui-night:text-gray-100 whitespace-nowrap">
                 {{ h.time|date:"D H:i" }}
               </th>
               <td class="px-6 py-4">{{ h.sunrise|date:"H:i" }}</td>

--- a/conditions/templates/conditions/location_forecast.html
+++ b/conditions/templates/conditions/location_forecast.html
@@ -169,8 +169,8 @@
     <div class="mt-6 sm:mt-8 w-full max-w-4xl mx-auto">
       <h2 class="text-base sm:text-lg font-semibold mb-2">Detailed Conditions</h2>
       <div class="responsive-table">
-        <table class="w-full text-sm text-left text-gray-700 bg-white shadow rounded-lg text-night-muted bg-night-surface">
-          <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+          <table class="w-full text-sm text-left text-gray-700 bg-white shadow rounded-lg text-night-muted bg-night-surface">
+            <thead class="text-xs text-gray-700 uppercase bg-gray-50 ui-night:text-gray-200 ui-night:bg-gray-800">
             <tr>
               <th scope="col" class="px-3 sm:px-6 py-3">Time</th>
               <th scope="col" class="px-3 sm:px-6 py-3 hidden sm:table-cell">Sunrise</th>
@@ -184,9 +184,9 @@
             </tr>
           </thead>
           <tbody>
-            {% for h in hours %}
-              <tr class="border-b hover:bg-gray-50">
-                <th scope="row" class="px-3 sm:px-6 py-3 sm:py-4 font-medium text-gray-900 whitespace-nowrap text-xs sm:text-sm">
+              {% for h in hours %}
+                <tr class="border-b hover:bg-gray-50 ui-night:border-gray-700 ui-night:hover:bg-gray-800">
+                  <th scope="row" class="px-3 sm:px-6 py-3 sm:py-4 font-medium text-gray-900 ui-night:text-gray-100 whitespace-nowrap text-xs sm:text-sm">
                   {{ h.time|date:"D H:i" }}
                 </th>
                 <td class="px-3 sm:px-6 py-3 sm:py-4 hidden sm:table-cell text-xs sm:text-sm">{{ h.sunrise|date:"H:i" }}</td>

--- a/snorkelforecast/static/css/ui.css
+++ b/snorkelforecast/static/css/ui.css
@@ -19,8 +19,8 @@
 .ui-night .card-enhanced { border-color: rgba(255,255,255,.08); }
 
 /* Night helpers for when Tailwind variants are unavailable */
-.ui-night .bg-night-surface { background-color: #1f2937; }
-.ui-night .text-night-muted { color: #d1d5db; }
+.ui-night .bg-night-surface { background-color: #374151; }
+.ui-night .text-night-muted { color: #e5e7eb; }
 
 /* Badges */
 .badge { display: inline-flex; align-items: center; gap: .375rem; padding: .25rem .5rem; border-radius: 9999px; font-size: .75rem; font-weight: 600; }


### PR DESCRIPTION
## Summary
- refine night surface and text colors for better contrast
- adjust table headers and rows to use night theme colors

## Testing
- `uv run ruff check .`
- `uv run python snorkelforecast/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689645bfa0ec8330b7c59aa55a868e79