### PR TITLE
feat: relax snorkeling thresholds

### DIFF
--- a/conditions/snorkel.py
+++ b/conditions/snorkel.py
@@ -12,15 +12,15 @@ from .models import ForecastHour
 
 CARBONERAS = {"lat": 36.997, "lon": -1.896}
 THRESHOLDS = {
-    "wave_height": 0.3,  # m
-    "wind_speed": 4.5,  # m/s (~10 mph)
-    "sea_surface_temperature": (22, 29),  # °C
+    "wave_height": 0.36,  # m
+    "wind_speed": 5.4,  # m/s (~12 mph)
+    "sea_surface_temperature": (20.6, 30.4),  # °C
 }
 
 THRESHOLDS.update(
     {
-        "current_velocity": 0.3,  # m/s
-        "slack_window_minutes": 60,
+        "current_velocity": 0.36,  # m/s
+        "slack_window_minutes": 72,
     }
 )
 

--- a/conditions/templates/conditions/homepage.html
+++ b/conditions/templates/conditions/homepage.html
@@ -111,9 +111,9 @@
         Our forecasts combine multiple weather factors to determine the best snorkeling conditions:
       </p>
       <ul class="space-y-2 text-sm sm:text-base">
-        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Wave Height:</strong> calm waters under 0.3 meters.</span></li>
-        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Wind Speed:</strong> light winds under 4.5 m/s.</span></li>
-        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Water Temperature:</strong> between 22°C and 29°C.</span></li>
+        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Wave Height:</strong> calm waters under 0.36 meters.</span></li>
+        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Wind Speed:</strong> light winds under 5.4 m/s.</span></li>
+        <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Water Temperature:</strong> between 20.6°C and 30.4°C.</span></li>
         <li class="flex items-start"><span class="text-blue-600 font-bold mr-2">•</span><span><strong>Daylight Hours:</strong> rated only during daylight for safety and visibility.</span></li>
       </ul>
     </div>

--- a/conditions/templates/conditions/index.html
+++ b/conditions/templates/conditions/index.html
@@ -63,9 +63,9 @@
             We consider snorkeling conditions to be ideal when all of the following criteria, fetched from the Open-Meteo API, are met during daylight hours (between sunrise and sunset):
         </p>
         <ul class="list-disc list-inside mt-2">
-            <li><strong>Wave height</strong> is less than 0.3 meters.</li>
-            <li><strong>Wind speed</strong> is below 4.5 meters/second.</li>
-            <li><strong>Sea surface temperature</strong> is between 22°C and 29°C.</li>
+            <li><strong>Wave height</strong> is less than 0.36 meters.</li>
+            <li><strong>Wind speed</strong> is below 5.4 meters/second.</li>
+            <li><strong>Sea surface temperature</strong> is between 20.6°C and 30.4°C.</li>
         </ul>
     </div>
 

--- a/conditions/templates/conditions/location_forecast.html
+++ b/conditions/templates/conditions/location_forecast.html
@@ -223,10 +223,10 @@
             We consider snorkeling conditions to be ideal when all of the following criteria, fetched from the Open-Meteo API, are met during daylight hours (between sunrise and sunset):
         </p>
         <ul class="list-disc list-inside mt-2 text-sm sm:text-base space-y-1">
-            <li><strong>Wave height</strong> is less than 0.3 meters.</li>
-            <li><strong>Wind speed</strong> is below 4.5 meters/second.</li>
-            <li><strong>Sea surface temperature</strong> is between 22°C and 29°C.</li>
-            <li><strong>Within ±60&nbsp;min of high tide</strong> and currents ≤ 0.3&nbsp;m/s.</li>
+            <li><strong>Wave height</strong> is less than 0.36 meters.</li>
+            <li><strong>Wind speed</strong> is below 5.4 meters/second.</li>
+            <li><strong>Sea surface temperature</strong> is between 20.6°C and 30.4°C.</li>
+            <li><strong>Within ±72&nbsp;min of high tide</strong> and currents ≤ 0.36&nbsp;m/s.</li>
         </ul>
     </div>
 
@@ -298,20 +298,20 @@
           const tideData24 = [{% for h in hours_24 %}{{ h.sea_level_height|floatformat:2 }}{% if not forloop.last %}, {% endif %}{% endfor %}];
           const seasonLabels = [{% for l in season_labels %}'{{ l }}'{% if not forloop.last %}, {% endif %}{% endfor %}];
           const seasonData = [{% for s in season_scores %}{% if s is not None %}{{ s }}{% else %}null{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}];
-          const waveThreshold = Array(labels.length).fill(0.3);
-          const windThreshold = Array(labels.length).fill(4.5);
+          const waveThreshold = Array(labels.length).fill(0.36);
+          const windThreshold = Array(labels.length).fill(5.4);
           const perfectThreshold = Array(labels.length).fill(0.8);
           const okThreshold = Array(labels.length).fill(0.6);
           const notGoodThreshold = Array(labels.length).fill(0.4);
 
-          const waveThreshold24 = Array(labels24.length).fill(0.3);
-          const windThreshold24 = Array(labels24.length).fill(4.5);
+          const waveThreshold24 = Array(labels24.length).fill(0.36);
+          const windThreshold24 = Array(labels24.length).fill(5.4);
           const perfectThreshold24 = Array(labels24.length).fill(0.8);
           const okThreshold24 = Array(labels24.length).fill(0.6);
           const notGoodThreshold24 = Array(labels24.length).fill(0.4);
 
-          const idealMin = 22;
-          const idealMax = 29;
+          const idealMin = 20.6;
+          const idealMax = 30.4;
           const scaleMax = 35; // max temperature for scale
           const avgTemp = tempData.reduce((a, b) => a + b, 0) / tempData.length;
           const avgTemp24 = tempData24.reduce((a, b) => a + b, 0) / tempData24.length;
@@ -449,7 +449,7 @@
                   tension: 0.3
                 },
                 {
-                  label: 'Ideal Threshold (0.3 m)',
+                  label: 'Ideal Threshold (0.36 m)',
                   data: waveThreshold24,
                   borderColor: 'rgb(239,68,68)',
                   borderDash: [6,6],
@@ -475,7 +475,7 @@
                   tension: 0.3
                 },
                 {
-                  label: 'Ideal Threshold (0.3 m)',
+                  label: 'Ideal Threshold (0.36 m)',
                   data: waveThreshold,
                   borderColor: 'rgb(239,68,68)',
                   borderDash: [6,6],
@@ -501,7 +501,7 @@
                   tension: 0.3
                 },
                 {
-                  label: 'Ideal Threshold (4.5 m/s)',
+                  label: 'Ideal Threshold (5.4 m/s)',
                   data: windThreshold24,
                   borderColor: 'rgb(239,68,68)',
                   borderDash: [6,6],
@@ -527,7 +527,7 @@
                   tension: 0.3
                 },
                 {
-                  label: 'Ideal Threshold (4.5 m/s)',
+                  label: 'Ideal Threshold (5.4 m/s)',
                   data: windThreshold,
                   borderColor: 'rgb(239,68,68)',
                   borderDash: [6,6],


### PR DESCRIPTION
## Summary
- make snorkeling condition algorithm 20% less pessimistic by increasing wave, wind, current, and temperature thresholds
- refresh location and homepage copy to describe new thresholds

## Testing
- `uv run ruff check .`
- `uv run python snorkelforecast/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ad91a4e7d48330b0dd7d348ba70e2b